### PR TITLE
Add type specifications to error structs

### DIFF
--- a/priv/templates/client.ex.eex
+++ b/priv/templates/client.ex.eex
@@ -9,6 +9,12 @@ defmodule <%= @module %>.Client do
     """
     defexception [:status, :body, :message]
 
+    @type t :: %__MODULE__{
+            status: non_neg_integer(),
+            body: any(),
+            message: String.t()
+          }
+
     def exception({status, body}) do
       %__MODULE__{
         status: status,
@@ -23,6 +29,11 @@ defmodule <%= @module %>.Client do
     Represents a transport-level error (network, timeout, DNS, etc.).
     """
     defexception [:reason, :message]
+
+    @type t :: %__MODULE__{
+            reason: any(),
+            message: String.t()
+          }
 
     def exception(reason) do
       %__MODULE__{


### PR DESCRIPTION
Fixes #2

**What does this PR do?**
Adds type specifications (@type) to the HTTPError and TransportError exception structs in the client template. This provides better documentation and compile-time type checking for users of generated API clients.

**Screenshots**
N/A - This is a code-only change to template files.

**Does this PR require any external coordination to deploy?**
No - This change is backwards compatible and only adds type specifications to existing structs.

**Additional context**
The type specifications added:
- `HTTPError.t()` with fields: `status` (non_neg_integer), `body` (any), and `message` (String.t)
- `TransportError.t()` with fields: `reason` (any) and `message` (String.t)

All tests pass successfully after these changes.