### PR TITLE
Fix tag filtering to support all tags in multi-tag operations

### DIFF
--- a/test/portico/helpers_test.exs
+++ b/test/portico/helpers_test.exs
@@ -167,7 +167,7 @@ defmodule Portico.HelpersTest do
       assert length(result["content"]) == 2
     end
 
-    test "uses first tag when operation has multiple tags" do
+    test "includes operation under all tags when operation has multiple tags" do
       paths = [
         %SpecPath{
           path: "/items",
@@ -180,9 +180,22 @@ defmodule Portico.HelpersTest do
       result = Helpers.group_operations_by_tag(paths)
 
       assert Map.has_key?(result, "primary")
-      assert not Map.has_key?(result, "secondary")
-      assert not Map.has_key?(result, "tertiary")
+      assert Map.has_key?(result, "secondary")
+      assert Map.has_key?(result, "tertiary")
       assert length(result["primary"]) == 1
+      assert length(result["secondary"]) == 1
+      assert length(result["tertiary"]) == 1
+
+      # Verify the same operation appears under each tag
+      [{path1, op1}] = result["primary"]
+      [{path2, op2}] = result["secondary"]
+      [{path3, op3}] = result["tertiary"]
+      assert path1.path == "/items"
+      assert path2.path == "/items"
+      assert path3.path == "/items"
+      assert op1.method == "get"
+      assert op2.method == "get"
+      assert op3.method == "get"
     end
 
     test "falls back to path when no tags are present" do


### PR DESCRIPTION
## Summary
- Fixed tag filtering to properly handle OpenAPI operations with multiple tags
- Operations with multiple tags now appear in all relevant modules, not just the first tag's module
- Tag filtering with `--tag` option now works with any of an operation's tags

## Problem
When an OpenAPI operation had multiple tags (e.g., `["users", "admin", "reports"]`), the current implementation only used the first tag for:
1. Module generation - operations only appeared in the first tag's module
2. Tag filtering - the `--tag` option could only filter by the first tag

## Solution
Modified the `group_operations_by_tag` function in `lib/portico/helpers.ex` to create entries for ALL tags an operation has, not just the first one. This ensures:
- Operations with multiple tags appear in all relevant tag modules
- Tag filtering works with any of an operation's tags
- Maintains backward compatibility for single-tag and untagged operations

Fixes #6