### PR TITLE
Handle comparison operators in parameter names

### DIFF
--- a/lib/portico/spec/parameter.ex
+++ b/lib/portico/spec/parameter.ex
@@ -1,9 +1,56 @@
 defmodule Portico.Spec.Parameter do
   @moduledoc """
   Represents a parameter in the Portico specification.
+
   A parameter is a piece of data that can be passed to an API endpoint.
   It includes details such as the parameter name, location (in, path, query, header, cookie),
   description, schema, content, style, and whether it is required or deprecated.
+
+  ## Parameter Name Normalization
+
+  Parameter names from OpenAPI specs are normalized to valid Elixir identifiers
+  for use in generated code. The original name is preserved in the `name` field,
+  while the normalized version is stored in `internal_name`.
+
+  Normalization rules (applied in order):
+
+  - `@` → `at_`
+  - `$` → `dollar_`
+  - `.` → `_`
+  - Converted to snake_case via `Macro.underscore/1`
+  - `-` → removed
+  - `[` → `_`
+  - `]` → removed
+  - `<=` → `_lte` (less than or equal)
+  - `>=` → `_gte` (greater than or equal)
+  - `<>` → `_ne` (not equal)
+  - `!=` → `_ne` (not equal)
+  - `<` → `_lt` (less than)
+  - `>` → `_gt` (greater than)
+  - `=` → `_eq` (equal)
+  - Reserved Elixir keywords get `_` suffix
+
+  ## Examples
+
+      iex> param = Portico.Spec.Parameter.parse(%{"name" => "DateSent<", "in" => "query"})
+      iex> param.name
+      "DateSent<"
+      iex> param.internal_name
+      "date_sent_lt"
+
+      iex> param = Portico.Spec.Parameter.parse(%{"name" => "created[gte]", "in" => "query"})
+      iex> param.name
+      "created[gte]"
+      iex> param.internal_name
+      "created_gte"
+
+      iex> param = Portico.Spec.Parameter.parse(%{"name" => "user-id", "in" => "path"})
+      iex> param.internal_name
+      "userid"
+
+      iex> param = Portico.Spec.Parameter.parse(%{"name" => "end", "in" => "query"})
+      iex> param.internal_name
+      "end_"
   """
 
   @type t() :: %__MODULE__{
@@ -70,6 +117,13 @@ defmodule Portico.Spec.Parameter do
     |> String.replace("-", "")
     |> String.replace("[", "_")
     |> String.replace("]", "")
+    |> String.replace("<=", "_lte")
+    |> String.replace(">=", "_gte")
+    |> String.replace("<>", "_ne")
+    |> String.replace("!=", "_ne")
+    |> String.replace("<", "_lt")
+    |> String.replace(">", "_gt")
+    |> String.replace("=", "_eq")
     |> escape_parameter_name()
   end
 

--- a/test/portico/spec/parameter_test.exs
+++ b/test/portico/spec/parameter_test.exs
@@ -117,6 +117,53 @@ defmodule Portico.Spec.ParameterTest do
       end
     end
 
+    test "handles comparison operators in parameter names" do
+      test_cases = [
+        # Less than
+        {"DateSent<", "date_sent_lt"},
+        {"value<", "value_lt"},
+        {"created_at<", "created_at_lt"},
+        # Greater than
+        {"DateSent>", "date_sent_gt"},
+        {"value>", "value_gt"},
+        {"updated_at>", "updated_at_gt"},
+        # Less than or equal
+        {"DateSent<=", "date_sent_lte"},
+        {"price<=", "price_lte"},
+        {"count<=", "count_lte"},
+        # Greater than or equal
+        {"DateSent>=", "date_sent_gte"},
+        {"price>=", "price_gte"},
+        {"score>=", "score_gte"},
+        # Equal
+        {"status=", "status_eq"},
+        {"type=", "type_eq"},
+        # Not equal (both styles)
+        {"status!=", "status_ne"},
+        {"type<>", "type_ne"},
+        # Complex cases with brackets (like Stripe API)
+        {"created[lt]", "created_lt"},
+        {"created[gt]", "created_gt"},
+        {"created[lte]", "created_lte"},
+        {"created[gte]", "created_gte"},
+        # Mixed cases
+        {"DateCreated>=", "date_created_gte"},
+        {"user-count<", "usercount_lt"},
+        {"filters[price]>=", "filters_price_gte"}
+      ]
+
+      for {input_name, expected_internal} <- test_cases do
+        input = %{"name" => input_name, "in" => "query"}
+        param = Parameter.parse(input)
+
+        assert param.name == input_name,
+               "Expected name to be #{input_name}, got #{param.name}"
+
+        assert param.internal_name == expected_internal,
+               "Expected internal_name to be #{expected_internal} for input #{input_name}, got #{param.internal_name}"
+      end
+    end
+
     test "escapes Elixir reserved words" do
       test_cases = [
         {"__CALLER__", "__caller__"},


### PR DESCRIPTION
Fixes #13

**What does this PR do?**

Adds normalization for comparison operators (`<`, `>`, `<=`, `>=`, `=`, `!=`, `<>`) in parameter names to prevent syntax errors during code generation.

**Changes**

- Updated `normalize_name/1` to replace operators with valid suffixes (`_lt`, `_gt`, `_lte`, `_gte`, `_eq`, `_ne`)
- Added module documentation explaining normalization rules
- Added 22 test cases covering operator transformations

**Example**

`DateSent<` → `:date_sent_lt`
`created[gte]` → `:created_gte`

**Testing**

All 197 tests pass, including new operator-specific tests.

**Does this PR require any external coordination to deploy?**

No.